### PR TITLE
Add talk titles to schedule table

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -9,11 +9,11 @@
   <tbody>
     <tr>
       <td>9:55&ndash;10:30</td>
-      <td><a href="/schedule/#ricardo-mendes">Ricardo Mendes</a></td>
+      <td><a href="/schedule/#ricardo-mendes">Opening Keynote by Ricardo Mendes</a></td>
     </tr>
     <tr>
       <td>10:30&ndash;11:15</td>
-      <td><a href="/schedule/#jorge-lainfiesta">Jorge Lainfiesta</a></td>
+      <td><a href="/schedule/#jorge-lainfiesta">Designing Immutable data flows in Ember by Jorge Lainfiesta</a></td>
     </tr>
     <tr>
       <td>11:15&ndash;12:00</td>
@@ -25,7 +25,7 @@
     </tr>
     <tr>
       <td>13:30&ndash;14:00</td>
-      <td><a href="/schedule/#michael-fritz">Michael Fritz</a></td>
+      <td><a href="/schedule/#michael-fritz">Interactive Maps with Ember.js Michael Fritz</a></td>
     </tr>
     <tr>
       <td>14:15&ndash;14:45</td>
@@ -33,7 +33,7 @@
     </tr>
     <tr>
       <td>15:00&ndash;15:30</td>
-      <td><a href="/schedule/#ivan-vanderbyl">Ivan Vanderbyl</a></td>
+      <td><a href="/schedule/#ivan-vanderbyl">Building the Progressive Web App for HackerNews.io in Ember by Ivan Vanderbyl</a></td>
     </tr>
     <tr>
       <td>15:30&ndash;16:00</td>
@@ -41,11 +41,11 @@
     </tr>
     <tr>
       <td>16:00&ndash;16:30</td>
-      <td><a href="/schedule/#adrian-zalewski">Adrian Zalewski</a></td>
+      <td><a href="/schedule/#adrian-zalewski">Promoting Ember's best practices by linting code by Adrian Zalewski</a></td>
     </tr>
     <tr>
       <td>16:45&ndash;17:15</td>
-      <td><a href="/schedule/#marie-chatfield">Marie Chatfield</a></td>
+      <td><a href="/schedule/#marie-chatfield">Deep Dive on Ember Events by Marie Chatfield</a></td>
     </tr>
     <tr>
       <td>17:30&ndash;18:00</td>
@@ -69,11 +69,11 @@
     </tr>
     <tr>
       <td>10:30&ndash;11:15</td>
-      <td><a href="/schedule/#sarup-banskota">Sarup Banskota</td>
+      <td><a href="/schedule/#sarup-banskota">Adopting better Ember patterns by Sarup Banskota</td>
     </tr>
     <tr>
       <td>11:15&ndash;12:00</td>
-      <td><a href="/schedule/#jakub-niechcial">Kuba Niechciał</a></td>
+      <td><a href="/schedule/#jakub-niechcial">Improving the UX is the developers job by Kuba Niechciał</a></td>
     </tr>
     <tr>
       <td>12:00&ndash;13:30</td>
@@ -81,7 +81,7 @@
     </tr>
     <tr>
       <td>13:30&ndash;14:00</td>
-      <td><a href="/schedule/#daniel-sudol">Daniel Sudol</a></td>
+      <td><a href="/schedule/#daniel-sudol">Writing tests like a speed demon with data builder patterns by Daniel Sudol</a></td>
     </tr>
     <tr>
       <td>14:15&ndash;14:45</td>
@@ -89,7 +89,7 @@
     </tr>
     <tr>
       <td>15:00&ndash;15:30</td>
-      <td><a href="/schedule/#alex-blom">Alex Blom</a></td>
+      <td><a href="/schedule/#alex-blom">Hybrid Apps with Ember/Glimmer by Alex Blom</a></td>
     </tr>
     <tr>
       <td>15:30&ndash;16:00</td>
@@ -105,7 +105,7 @@
     </tr>
     <tr>
       <td>17:30&ndash;18:00</td>
-      <td><a href="/schedule/#erik-bryn">Erik Bryn</a></td>
+      <td><a href="/schedule/#erik-bryn">Closing keynote by Erik Bryn</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
See #57. I realize we don't have the titles for about half of the talks but I think it's still worth to merge this so that we share the info that we ourselves have.