### PR TITLE
Update Design of Speakers Section

### DIFF
--- a/css/app.scss
+++ b/css/app.scss
@@ -29,6 +29,7 @@ p {
   }
 
   &.speakers {
+    background-color: #fde3df;
     color: black !important;
 
     a {
@@ -38,7 +39,7 @@ p {
   }
 
   &.alternate {
-    background: #e25641;
+    background: #30adc3;
 
     a {
       color: #bdccd4;
@@ -53,7 +54,7 @@ p {
   }
 
   &.venue-bg {
-    background: rgb(128,197,234);
+    background: #30adc3;
 
     a {
       color: #460D0D;

--- a/css/app.scss
+++ b/css/app.scss
@@ -32,9 +32,18 @@ p {
     background-color: #fde3df;
     color: black !important;
 
+    h4 {
+      margin-bottom: 1em;
+    }
+
     a {
       color: #460D0D;
       font-weight: bold;
+    }
+
+    hr {
+      border-top: 1px solid #dec9c5;
+      margin: 4em 0;
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: EmberFest
   <tito-button event="emberfest/emberfest-2019">Get your tickets now!</tito-button>
 </div>
 
-<div class="row section alternate" id="content-start" style="background-color: #30adc3">
+<div class="row section alternate" id="content-start">
   <div class="row">
     <div class="col-md-6 col-md-offset-3 col-xs-10 col-xs-offset-1 col-sm-8 col-sm-offset-2">
       <p>
@@ -29,7 +29,7 @@ title: EmberFest
   </div>
 </div>
 
-<div class="row section speakers" id="speakers" style="background-color: #fde3df;">
+<div class="row section speakers" id="speakers">
   <div class="row">
     <div class="col-md-6 col-md-offset-3 col-xs-10 col-xs-offset-1 col-sm-8 col-sm-offset-2">
       <h4>Speakers</h4>
@@ -71,7 +71,7 @@ title: EmberFest
 </div>
 </div>
 
-<div class="row section venue-bg location" style="background-color: #30adc3">
+<div class="row section venue-bg location">
   <div class="row">
     <div class="col-md-6 col-md-offset-3 col-xs-10 col-xs-offset-1 col-sm-8 col-sm-offset-2">
       <h4>The Venue</h4>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,9 @@ title: EmberFest
           <img class="img-circle img-responsive" src="images/godfrey-chan.jpg" alt="Godfrey Chan" />
         </div>
       </div>
+
+      <hr />
+
       <h4>Past Speakers</h4>
       <div class="row speaker-list">
         <div class="speaker col-md-4 col-md-offset-0 col-xs-4 col-xs-offset-0">

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ title: EmberFest
     <div class="col-md-6 col-md-offset-3 col-xs-10 col-xs-offset-1 col-sm-8 col-sm-offset-2">
       <h4>Speakers</h4>
       <div class="row speaker-list">
-        <div class="speaker col-md-4 col-md-offset-0 col-xs-4 col-xs-offset-0">
+        <div class="speaker col-md-4 col-md-offset-4 col-xs-4 col-xs-offset-4">
           <h5>Godfrey Chan</h5>
           <img class="img-circle img-responsive" src="images/godfrey-chan.jpg" alt="Godfrey Chan" />
         </div>


### PR DESCRIPTION
Follow-up to #163 

Adds the discussed design changes to make the speaker section look as follow:

![](https://cl.ly/ab1c68810fe7/Image%2525202019-07-16%252520at%2525202.20.33%252520AM.png)

and on more narrow screens:

![](https://cl.ly/8456fd18e49d/Image%2525202019-07-16%252520at%2525202.22.18%252520AM.png)

I also think it’s nicer to have a little bit more going on here while Godfrey is the only announced speaker, so this just adds a more visual separation to the speaker section. Let me know what you think!