### PR TITLE
Add EmberMap as Supporters sponsor

### DIFF
--- a/images/ember-map.svg
+++ b/images/ember-map.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 274.3 75" style="enable-background:new 0 0 274.3 75;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:url(#Background_1_);}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st2{fill:#333333;}
+	.st3{font-family:'AvenirNext-Medium';}
+	.st4{font-size:36.2068px;}
+</style>
+<title>Icons / EmberMap (text)</title>
+<desc>Created with Sketch.</desc>
+<g>
+	<g>
+		
+			<linearGradient id="Background_1_" gradientUnits="userSpaceOnUse" x1="40.9506" y1="134.2746" x2="38.6877" y2="136.5375" gradientTransform="matrix(31.9825 0 0 -31.9825 -1236.392 4368.0767)">
+			<stop  offset="0" style="stop-color:#FF9C40"/>
+			<stop  offset="1" style="stop-color:#FF5757"/>
+		</linearGradient>
+		<path id="Background" class="st0" d="M37.1,1.3L37.1,1.3c20,0,36.2,16.2,36.2,36.2l0,0c0,20-16.2,36.2-36.2,36.2l0,0
+			c-20,0-36.2-16.2-36.2-36.2l0,0C0.9,17.5,17.1,1.3,37.1,1.3z"/>
+		<path id="Center-flap-Copy" class="st1" d="M28.1,46c0,1.3-0.9,2.6-2.1,3l-9.3,3.4c-1.2,0.4-2.1-0.3-2.1-1.5V28.3
+			c0-1.3,0.9-2.6,2.1-3l9.3-3.4c1.2-0.4,2.1,0.3,2.1,1.5V46z"/>
+		<path id="Center-flap-Copy-2" class="st1" d="M30.4,46c0,1.3,0.9,2.6,2.1,3l9.3,3.4c1.2,0.4,2.1-0.3,2.1-1.5V28.3
+			c0-1.3-0.9-2.6-2.1-3l-9.3-3.4c-1.2-0.4-2.1,0.3-2.1,1.5V46z"/>
+		<path id="Center-flap-Copy-3" class="st1" d="M59.8,46.5c0,1.3-1,2.6-2.2,3l-9.3,3.1c-1.2,0.4-2.2-0.3-2.2-1.6V28.4
+			c0-1.3,1-2.6,2.2-3l9.3-3.1c1.2-0.4,2.2,0.3,2.2,1.6V46.5z"/>
+	</g>
+	<text transform="matrix(1 0 0 1 89.1913 51.0498)" class="st2 st3 st4">EmberMap</text>
+</g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -164,14 +164,19 @@ title: EmberFest
       <h6>Supporters</h6>
 
       <div class="row">
-        <div class="col-xs-2 col-xs-offset-4">
+        <div class="col-xs-2 col-xs-offset-2">
           <a href="https://www.phorest.com" title="Phorest">
             <img src="images/phorest.svg" class="img-responsive">
           </a>
         </div>
-        <div class="col-xs-5">
+        <div class="col-xs-3">
           <a href="http://stickermule.com/supports/emberfest19-sponsorship" title="Stickermule">
             <img src="images/sticker-mule.svg" class="img-responsive">
+          </a>
+        </div>
+        <div class="col-xs-4">
+          <a href="" title="EmberMap">
+            <img src="images/ember-map.svg" class="img-responsive">
           </a>
         </div>
       </div>


### PR DESCRIPTION
⚠️  This is based on https://github.com/emberfest/emberfest.github.io/pull/168, to avoid conflicts, as that adds another Supporters sponsor.

---

Closes #169

Obligatory preview link: https://cl.ly/70d259b51c75/Screen%252520Recording%2525202019-08-16%252520at%25252008.46%252520PM.mov

The Phorest signet is really making this section tricky, as that’s so narrow compared to everything else. Anyway, let me know what you think. It’d probably be better to move away from this Bootstrap stuff eventually, but for now, this should do.

If this looks good to you, just approve and merge it, as always! 👍 