### PR TITLE
Use correct casing for sponsor SVG file names

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,28 +137,28 @@ title: EmberFest
   </div>
   <div class="row">
     <a href="https://simplabs.com/" title="simplabs">
-      <img src="/images/sponsors/simplabs.svg" alt="simplabs logo" title="simplabs">
+      <img src="/images/sponsors/Simplabs.svg" alt="simplabs logo" title="simplabs">
     </a>
     <a href="https://getharvest.com/" title="Harvest">
-      <img src="/images/sponsors/harvest.svg" alt="Harvest logo" title="Harvest">
+      <img src="/images/sponsors/Harvest.svg" alt="Harvest logo" title="Harvest">
     </a>
     <a href="https://honeypot.io/" title="honeypot">
-      <img src="/images/sponsors/honeypot.svg" alt="honeypot logo" title="honeypot">
+      <img src="/images/sponsors/Honeypot.svg" alt="honeypot logo" title="honeypot">
     </a>
   </div>
 
   <div class="row">
     <a href="https://www.clark.de/" title="Clark">
-      <img src="/images/sponsors/clark.svg" alt="Clark logo" title="Clark">
+      <img src="/images/sponsors/Clark.svg" alt="Clark logo" title="Clark">
     </a>
     <a href="http://www.triptyk.eu" title="TRIPTYK">
-      <img src="/images/sponsors/TRIPTYK.svg" alt="Tryptik logo" title="Tryptik">
+      <img src="/images/sponsors/Triptyk.svg" alt="Tryptik logo" title="Tryptik">
     </a>
     <a href="https://www.crowdstrike.com" title="CrowdStrike">
-      <img src="/images/sponsors/crowdstrike.svg" alt="CrowdStrike logo" alt="CrowdStrike">
+      <img src="/images/sponsors/Crowdstrike.svg" alt="CrowdStrike logo" alt="CrowdStrike">
     </a>
     <a href="https://www.kloeckner-i.com/" title="kloeckner.i">
-      <img src="/images/sponsors/kloeckner-i.svg" alt="Kloeckner logo" title="Kloeckner">
+      <img src="/images/sponsors/Kloeckner-i.svg" alt="Kloeckner logo" title="Kloeckner">
     </a>
   </div>
 
@@ -191,10 +191,10 @@ title: EmberFest
 
   <div class="row">
     <a href="http://selleo.com" title="Selleo">
-      <img src="/images/sponsors/selleo.svg" class="img-responsive">
+      <img src="/images/sponsors/Selleo.svg" class="img-responsive">
     </a>
     <a href="http://wyeworks.com" title="Wyeworks">
-      <img src="/images/sponsors/wyeworks.svg" class="img-responsive">
+      <img src="/images/sponsors/Wyeworks.svg" class="img-responsive">
     </a>
     <a href="https://linkfire.com/" title="linkfire">
       <img src="/images/sponsors/linkfire.svg" class="img-responsive">
@@ -203,10 +203,10 @@ title: EmberFest
 
   <div class="row">
     <a href="https://linkedin.com/" title="linkedin">
-      <img src="/images/sponsors/linkedin.svg" class="img-responsive">
+      <img src="/images/sponsors/LinkedIn.svg" class="img-responsive">
     </a>
     <a href="https://www.phorest.com" title="Phorest">
-      <img src="/images/sponsors/phorest.svg" title="Phorest" alt="Phorest logo">
+      <img src="/images/sponsors/Phorest.svg" title="Phorest" alt="Phorest logo">
     </a>
     <a href="https://embermap.com" title="EmberMap">
       <img src="/images/sponsors/EmberMap.svg" title="EmberMap" alt="EmberMap logo">


### PR DESCRIPTION
The past sponsors section currently shows many logos as missing:

![image](https://user-images.githubusercontent.com/1042339/119998476-05b8cf80-bfd1-11eb-89cc-9cc33dd6f76c.png)

Turns out, all the affected files are in title/upper case, rather than all lower case. Even though it’d have been nicer to rename the files, Git doesn’t recognize changes to casing, so instead of `rm` and `add`ing them, I just edited the index.