### PR TITLE
CFP link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
       <p style="text-align: center;">Thanks to <a class="footer__links" href="https://ti.to">Tito</a> for supporting EmberFest <br/>Graphics from the Noun Project and Freevector</p>
     </div>
     <div class="footer__bottomNav">
-      <a class="footer__links" href="/sponsorship.pdf" download>Sponsorship</a> • <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
+      <a class="footer__links" href="https://cfp.emberfest.eu/events/emberfest-2021">CFP</a> • <a class="footer__links" href="/sponsorship.pdf" download>Sponsorship</a> • <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
     </div>
   </div>
   <hr>

--- a/css/app.scss
+++ b/css/app.scss
@@ -586,6 +586,9 @@ h4 {
   flex-direction: column;
   padding-top: var(--space-l);
   padding-bottom: var(--space-l);
+  padding-left: var(--space-l);
+  padding-right: var(--space-l);
+  text-align: center;
 }
 
 .footer__copyright {}
@@ -872,9 +875,10 @@ hr {
     margin-bottom: var(--space-xl);
   }
 
-  .footer {
-    // margin-left: var(--space-m);
-    // margin-right: var(--space-m);
+  .footer_bottomNav {
+    padding-left: var(--space-l);
+    padding-right: var(--space-l);
+    text-align: center;
   }
 
 
@@ -1124,9 +1128,10 @@ hr {
   }
 
 
-  .footer {
-    // margin-left: var(--space-xl);
-    // margin-right: var(--space-xl);
+  .footer__bottomNav {
+    padding-left: var(--space-l);
+    padding-right: var(--space-l);
+    text-align: center;
   }
 
   .mailing-list {
@@ -1417,6 +1422,12 @@ hr {
 
   .footer {
     background-size: cover;
+  }
+
+  .footer__bottomNav {
+    padding-left: var(--space-l);
+    padding-right: var(--space-l);
+    text-align: right;
   }
 
   .mailing-list {

--- a/css/app.scss
+++ b/css/app.scss
@@ -1467,3 +1467,19 @@ hr {
      }
     }
 }
+
+.cfp-link {
+  text-align: center;
+  padding: var(--space-l) 0;
+
+  .custom-button {
+    text-decoration: none;
+    display: inline-block;
+    margin: 0 auto;
+    background: #2a3b90;
+    border-radius: 10px;
+    text-align: center;
+    padding: var(--space-m);
+    font-weight: bold;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -123,6 +123,9 @@ title: EmberFest
       </div>
     </div>
   </div>
+  <div class="cfp-link">
+    <a href="https://cfp.emberfest.eu/events/emberfest-2021" class="custom-button">Submit a talk for EmberFest 2021</a>
+  </div>
 </div><!-- End Past Speakers Section-->
 
 <div class="venue-bg">


### PR DESCRIPTION
This adds the CFP link to the footer and the content section:

<img width="712" alt="Bildschirmfoto 2021-06-10 um 21 27 48" src="https://user-images.githubusercontent.com/1510/121585322-bd6aca00-ca32-11eb-8c04-db49091766e7.png">
<img width="705" alt="Bildschirmfoto 2021-06-10 um 21 27 53" src="https://user-images.githubusercontent.com/1510/121585326-bf348d80-ca32-11eb-970e-948a1ff860c5.png">

closes #228 