### PR TITLE
2021: Add Stickermule as Supporter

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@ title: EmberFest
     </div>
 
     <div class="row supporters">
-      <a href="http://stickermule.com/supports/emberfest21-sponsorship" title="Stickermule">
+      <a href="https://www.stickermule.com/uses/laptop-stickers?utm_source=google&utm_id=emberfest21" title="Stickermule">
         <img src="/images/sponsors/stickermule.svg" title="Stickermule" alt="Stickermule logo">
       </a>
     </div>

--- a/index.html
+++ b/index.html
@@ -156,14 +156,16 @@ title: EmberFest
         <img src="/images/sponsors/Phorest.svg" title="Phorest" alt="Phorest logo">
       </a>
     </div> 
-    <!--<div class="row">
+
+    <div class="row">
       <h6>Supporters</h6>
     </div>
+
     <div class="row supporters">
       <a href="http://stickermule.com/supports/emberfest21-sponsorship" title="Stickermule">
         <img src="/images/sponsors/stickermule.svg" title="Stickermule" alt="Stickermule logo">
       </a>
-    </div>-->
+    </div>
   </div>
 </div>
 <!-- End Sponsors Section-->


### PR DESCRIPTION
As per https://3.basecamp.com/4551353/buckets/17581315/todos/4065495747

Here are a bunch of random screenshots again:

![image](https://user-images.githubusercontent.com/1042339/129970255-78d0f7f2-d543-4462-8ff3-6b6595940745.png)

![image](https://user-images.githubusercontent.com/1042339/129970300-d3ba623b-1d4d-4859-af87-fbf24f4e7ff6.png)

![image](https://user-images.githubusercontent.com/1042339/129970331-84831e1d-4e50-4650-add0-a01d8c63e790.png)

![image](https://user-images.githubusercontent.com/1042339/129970354-9fa95bb7-0527-4679-aed3-b1c7eeea4c42.png)

![image](https://user-images.githubusercontent.com/1042339/129970373-cbfbbd12-b5af-42f4-bf4a-0d51799798a1.png)

As mentioned previously, I think the mobile styles for sponsors make the logos too small, and should probably break into a 1-column layout, but that’s part of the overall design and not a thing added/changed here, so we can do that in a follow-up if anyone shares those concerns.

Feel free to just merge it after reviewing the screenshots, btw!