### PR TITLE
Fix broken force majeure styling

### DIFF
--- a/cancellation/index.html
+++ b/cancellation/index.html
@@ -15,7 +15,7 @@ title: EmberFest
     <p class="content-text text-align">
       We are unable to offer refunds within 30 days of the conference, however your ticket can be reassigned at any time to a different attendee. To reassign your ticket, please follow the link on your original confirmation email.
     </p>
-    <h3>“Force majeure” events</h3>
-    <p>Should the conference be cancelled for any reason (including due to restrictions because of the Coronavirus pandemic), purchased tickets will be valid for the next year.</p>
+    <h3 class="pre-heading__text text-align">“Force majeure” events</h3>
+    <p class="content-text text-align">Should the conference be cancelled for any reason (including due to restrictions because of the Coronavirus pandemic), purchased tickets will be valid for the next year.</p>
   </div> <!-- paragraphLarge -->
 </div> <!-- wrapper -->


### PR DESCRIPTION
Soy muy estupido but I got this wrong the first time.

Before:
<img width="1455" alt="Screenshot 2021-09-23 at 17 29 57" src="https://user-images.githubusercontent.com/5022/134537408-34f7f354-85ff-4721-9b2c-738fbb8a17e8.png">

After:
<img width="1063" alt="Screenshot 2021-09-23 at 17 30 39" src="https://user-images.githubusercontent.com/5022/134537567-bf85c70f-54ad-4c99-9cba-b28514a1b211.png">

