### PR TITLE
Specify that times are local in schedule

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -1,5 +1,6 @@
 <h5>Day 1</h5>
 <h6>Sep 30, Thursday</h6>
+<div class="timezone-remark">(Times are local, CEST)</div>
 <table class="table schedule-table">
   <thead>
     <tr>
@@ -62,6 +63,7 @@
 
 <h5 class="day2">Day 2</h5>
 <h6>Oct 1, Friday</h6>
+<div class="timezone-remark">(Times are local, CEST)</div>
 <table class="table">
   <thead>
     <tr>

--- a/css/app.scss
+++ b/css/app.scss
@@ -132,7 +132,7 @@ html {
 //get-involved start
 
 .get-involved{
-  
+
   &__item{
     text-align: center;
     background-color: white;
@@ -168,7 +168,7 @@ html {
 //video-2019 start
 
 .video-2019{
-   
+
     .video{
       max-width: 1088px;
       width: 100%;
@@ -176,7 +176,7 @@ html {
       margin: auto;
       margin-top: 3.1rem;
       height: 276px;
-      
+
       @include tablet{
         height: 400px;
       }
@@ -197,7 +197,7 @@ html {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 32px;
-    
+
     margin: auto;
 
     @include mobile{
@@ -266,7 +266,7 @@ html {
     flex-wrap: wrap;
     justify-content: flex-start;
     row-gap: 33px;
-    
+
     @include tablet{
       justify-content: space-between;
       column-gap: 70px;
@@ -282,7 +282,7 @@ html {
   }
 
   .location{
-    
+
 
     @include tablet{
       max-width: 48%;
@@ -355,13 +355,13 @@ html {
     line-height: 2.0rem;
     font-weight: bold;
   }
-  
+
   h5 {
     font-size: 1.5rem;
     line-height: 1.75rem;
     font-weight: bold;
   }
-  
+
   h6 {
     font-size: 1.25rem;
     line-height: 1.5rem;
@@ -534,10 +534,16 @@ html {
       font-weight: bold;
       margin-bottom: .5rem;
     }
-    
+
     h6 {
       font-size: 1.25rem;
       line-height: 1.5rem;
+    }
+
+    .timezone-remark {
+      color: #e25641;
+      text-align: center;
+      font-size: 0.75rem;
     }
 
     a[href] {

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -10,6 +10,7 @@ title: Schedule
     <div class="timetable full-timetable">
       <h5>Day 1</h5>
       <h6>Sep 30, Thursday</h6>
+      <div class="timezone-remark">(Times are local, CEST)</div>
       <table class="table schedule-table">
         <thead>
           <tr>
@@ -85,7 +86,7 @@ title: Schedule
               </p>
             </td>
           </tr>
-      
+
           <tr>
             <td class="schedule-table--timeslot">13:45&ndash;14:15</td>
             <td class="talk-details">
@@ -158,9 +159,10 @@ title: Schedule
           </tr>
         </tbody>
       </table>
-      
+
       <h5 class="day2">Day 2</h5>
       <h6>Oct 1, Friday</h6>
+      <div class="timezone-remark">(Times are local, CEST)</div>
       <table class="table">
         <thead>
           <tr>
@@ -196,7 +198,7 @@ title: Schedule
               <p>
                 Thanks to a problem-solving approach and powerful Ember addons, you will learn how to go further with your styleguide, step-by-step.
               </p>
-              <p>  
+              <p>
                 How to leverage custom lint rules? How to estimate and organise the update of your codebase? How to perform it incrementally?
               </p>
               <p>
@@ -282,7 +284,7 @@ title: Schedule
               <p>
                 Shodipo Ayomide is a Dev. Relations Manager at Stack Overflow with 9 years of experience in Technology and a track record in web & mobile applications engineering and community management on a global scale.
               </p>
-              <p>                 He has given talks/workshops at developer conferences around countries at conferences like React Atlanta, FutureSync Conference, VueJS Amsterdam, VueJS Toronto, APIDAYS Hong Kong, Frontend Love Conference Amsterdam, FOSSASIA, among many.
+              <p>                He has given talks/workshops at developer conferences around countries at conferences like React Atlanta, FutureSync Conference, VueJS Amsterdam, VueJS Toronto, APIDAYS Hong Kong, Frontend Love Conference Amsterdam, FOSSASIA, among many.
               </p>
             </td>
           </tr>
@@ -304,6 +306,6 @@ title: Schedule
           </tr>
         </tbody>
       </table>
-      
+
     </div>
 </div>


### PR DESCRIPTION
Alex made a great point about this in our call. This is important, especially for remote attendees

<img width="1150" alt="Screenshot 2021-09-23 at 17 41 58" src="https://user-images.githubusercontent.com/5022/134539489-2eb158af-694b-4520-ae08-ea959c2a8eb0.png">
.