### PR TITLE
Remove shodipo

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -109,12 +109,7 @@
       <td>Snack break</td>
     </tr>
     <tr>
-      <td class="schedule-table--timeslot">15:30&ndash;16:00</td>
-      <td><a href="/schedule/#shodipo-ayomide">Technical Principles for Developer Experience</a><span class="speaker">Shodipo Ayomide</span>
-      </td>
-    </tr>
-    <tr>
-      <td class="schedule-table--timeslot">16:15&ndash;16:45</td></td>
+      <td class="schedule-table--timeslot">15:30&ndash;16:15</td></td>
       <td><a href="/schedule/#panel-future-of-ember">Panel: The Future of Ember</a><span class="speaker">Tom Dale, Preston Sego, Ed Faulkner, Chris Manson</span>
       </td>
     </tr>

--- a/index.html
+++ b/index.html
@@ -97,12 +97,12 @@ title: EmberFest
         </div>
         <div class="speakers_item">
           <div class="speaker_image">
-            <img  src="/images/speakers/shodipo-ayomide.jpg" alt="Shodipo Ayomide">
+            <img  src="/images/speakers/nick-schot.jpg" alt="Nick Schot">
           </div>
-          <h6 class="speaker_name">Shodipo Ayomide</h6>
+          <h6 class="speaker_name">Nick Schot</h6>
           <div class="speakers_links">
-             <a  href=" https://twitter.com/developerayo"><img src="/images/twitterSmall.svg"/></a>
-             <a  href="https://www.linkedin.com/in/shodipo-ayomide/"><img src="/images/link.svg"></a>
+             <a  href="https://twitter.com/nickschot?lang=de"><img src="/images/twitterSmall.svg"/></a>
+             <a  href="https://www.linkedin.com/in/nick-schot-4936a030/"><img src="/images/link.svg"></a>
           </div>
         </div>
         <div class="speakers_item">

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -270,26 +270,7 @@ title: Schedule
             <td>Snack break</td>
           </tr>
           <tr>
-            <td class="schedule-table--timeslot">15:30&ndash;16:00</td>
-            <td class="talk-details">
-              <h6><a name="shodipo-ayomide">Technical Principles for Developer Experience</a></h6>
-              <p>
-                Developer experience (DX) is similar to how you see and understand user experience (UX) but the difference is DX focus is strictly on developers who consume certain API services, SDKs, or other services owned by a company or an organization.
-              </p>
-              <p>
-                This talk will explore why developer experience matters in every company providing a technical service, what makes a great developer experience team, and the relationship between building a great developer experience flow in a company with the public.
-              </p>
-              <h6 class="speaker">Shodipo Ayomide</h6>
-              <img src="/images/speakers/shodipo-ayomide.jpg" class="speaker">
-              <p>
-                Shodipo Ayomide is a Dev. Relations Manager at Stack Overflow with 9 years of experience in Technology and a track record in web & mobile applications engineering and community management on a global scale.
-              </p>
-              <p>                He has given talks/workshops at developer conferences around countries at conferences like React Atlanta, FutureSync Conference, VueJS Amsterdam, VueJS Toronto, APIDAYS Hong Kong, Frontend Love Conference Amsterdam, FOSSASIA, among many.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td class="schedule-table--timeslot">16:15&ndash;16:45</td></td>
+            <td class="schedule-table--timeslot">15:30&ndash;16:15</td></td>
             <td class="talk-details">
               <h6><a name="panel-future-of-ember">Panel: the future of Ember</a></h6>
               <p>


### PR DESCRIPTION
This removes Shodipo's talk from the schedule, moves the closing panel to an earlier time (and extends it), and replaces Shodipo's photo with Nick's on the homepage.