### PR TITLE
Clean site up for 2022

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
         <p>Thanks to <a class="footer__links" href="https://ti.to">Tito</a> for supporting EmberFest <br/>Graphics from the Noun Project and Freevector</p>
       </div>
     <div class="footer__bottomNav">
-      <a class="footer__links" href="https://cfp.emberfest.eu/events/emberfest-2021">CFP</a> • <a class="footer__links" href="/sponsorship.pdf" download>Sponsorship</a> • <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/corona-safety">Coronavirus & Safety</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
+      <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/corona-safety">Coronavirus & Safety</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
     </div>
   </div>
 </footer> <!-- footer -->

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="footer__wrapper--top">
       <img class="icon" src="/images/glasses.svg" alt="icon">
-      <p class="footer__copyright">&copy; 2017 - 2021 EmberFest</p>
+      <p class="footer__copyright">&copy; 2017 - 2022 EmberFest UG</p>
     </div>
     <div class="footer__wrapper--bottom">
       <div class="footer__pastEvents">

--- a/index.html
+++ b/index.html
@@ -16,9 +16,6 @@ title: EmberFest
       </div>
       <div class="introduction__text text-align">
         <p class="content-text">EmberFest is the European Community Ember Conference. If you’re looking for updates on the latest and greatest in Ember and Glimmer this is the place to be. EmberFest is also a great opportunity to get in touch with the European Ember Community (and friends from abroad) and hiring Ember talent.</p>
-        <p class="content-text">
-           In 2021, we’re back with a hybrid on-site/virtual event in September 🎉
-        </p>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -49,20 +49,6 @@ title: EmberFest
 
 
 <section class="section_wrapper">
-  <!-- Begin Video Section-->
-  <div class="video-2019 tb_padding">
-    <div class="container">
-      <div class="pre-heading">
-        <div class="laurel-image-left"><img src="/images/laurel-left.svg"></div>
-        <div class="pre-heading__text"><h3>Our last conference</h3></div>
-        <div class="laurel-image-right"><img src="/images/laurel-right.svg"></div>
-      </div>
-      <div class="content-text text-align"> EmberFest 2019 in Copenhagen was a blast! We captured some of the atmosphere and statements from speakers and attendees in this video.</div>
-      <iframe class="video" src="https://www.youtube.com/embed/8EyI_xyha6k" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-    </div>
-  </div><!-- End Video Section-->
-
   <!-- Begin Past Speakers Section-->
   <div class="speakers tb_padding custom_bg-1" id="speakers">
     <div class="container">


### PR DESCRIPTION
This cleans the site up for 2022:

* removes the old CPH video (to be replaced with one from Rome)
* updates copyright to extend until 2022
* removes the "we'll be back in 2021" text
* removes CfP/sponsorhip links from footer