### PR TITLE
Update libraries to make app build on M1 Macs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     concurrent-ruby (1.0.5)
     ethon (0.10.1)
       ffi (>= 1.3.0)
-    ffi (1.9.18)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
     html-proofer (3.7.2)
       activesupport (>= 4.2, < 6.0)
@@ -48,14 +48,16 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.8.0)
     minitest (5.10.2)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     parallel (1.11.2)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
+    racc (1.6.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -76,6 +78,9 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-sitemap
+
+RUBY VERSION
+   ruby 2.7.3p183
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
Those libraries are nokogiri and ffi which needs native C extensions.