### PR TITLE
fix(schedule): don't publish /schedule page until it is announced

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,4 +6,4 @@ sass:
 gems:
   - jekyll-sitemap
 
-exclude: [vendor]
+exclude: [vendor, schedule]


### PR DESCRIPTION
Right now there is no link pointing to it but emberfest.io/schedule is live (with broken styles, etc...).

We should not make the link public until we are ready for it.