### PR TITLE
fix broken links past editions

### DIFF
--- a/2017/privacy/index.html
+++ b/2017/privacy/index.html
@@ -1,0 +1,33 @@
+---
+layout: 2017/default
+title: Privacy
+---
+{% include 2017/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Privacy</h2>
+    <p class="content-text text-align">Emberfest uses Google Analytics to collect user statistics.</p>
+    <p class="content-text text-align">Google Analytics is a service that collects data about website visitors.</p>
+    <h3 class="pre-heading__text text-align">What Google Analytics records</h3>
+    <ul class="content-text">
+      <li>The referrer that let a user to this website</li>
+      <li>The duration of the visit</li>
+      <li>Information about the client used to access the website</li>
+      <li>other information</li>
+    </ul>
+    <h3 class="pre-heading__text text-align">How we use that data</h3>
+    <p class="content-text text-align">
+      The information recorded by Google Analytics allows us to better understand the audience of this website, what
+      content they’re accessing and how they get here. This allows us to make better decisions about design, writing
+                                    and marketing.</p>
+    <p class="content-text text-align">No personally identifying data is ever included in the reports that we run.</p>
+    <p class="content-text text-align">For further information please refer to the
+      <a href="http://www.google.com/analytics/tos.html">Google
+        Analytics Terms of Service</a>.</p>
+    <p class="content-text text-align">Google offers a
+      <a href="http://tools.google.com/dlpage/gaoptout?hl=en">browser plugin</a>
+      to opt out of the
+      Google Analytics tracking service.</p>
+  </div>
+</div>

--- a/2018/privacy/index.html
+++ b/2018/privacy/index.html
@@ -1,0 +1,33 @@
+---
+layout: 2018/default
+title: Privacy
+---
+{% include 2018/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Privacy</h2>
+    <p class="content-text text-align">Emberfest uses Google Analytics to collect user statistics.</p>
+    <p class="content-text text-align">Google Analytics is a service that collects data about website visitors.</p>
+    <h3 class="pre-heading__text text-align">What Google Analytics records</h3>
+    <ul class="content-text">
+      <li>The referrer that let a user to this website</li>
+      <li>The duration of the visit</li>
+      <li>Information about the client used to access the website</li>
+      <li>other information</li>
+    </ul>
+    <h3 class="pre-heading__text text-align">How we use that data</h3>
+    <p class="content-text text-align">
+      The information recorded by Google Analytics allows us to better understand the audience of this website, what
+      content they’re accessing and how they get here. This allows us to make better decisions about design, writing
+                  and marketing.</p>
+    <p class="content-text text-align">No personally identifying data is ever included in the reports that we run.</p>
+    <p class="content-text text-align">For further information please refer to the
+      <a href="http://www.google.com/analytics/tos.html">Google
+        Analytics Terms of Service</a>.</p>
+    <p class="content-text text-align">Google offers a
+      <a href="http://tools.google.com/dlpage/gaoptout?hl=en">browser plugin</a>
+      to opt out of the
+      Google Analytics tracking service.</p>
+  </div>
+</div>

--- a/2019/privacy/index.html
+++ b/2019/privacy/index.html
@@ -1,0 +1,33 @@
+---
+layout: 2019/default
+title: Privacy
+---
+{% include 2019/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Privacy</h2>
+    <p class="content-text text-align">Emberfest uses Google Analytics to collect user statistics.</p>
+    <p class="content-text text-align">Google Analytics is a service that collects data about website visitors.</p>
+    <h3 class="pre-heading__text text-align">What Google Analytics records</h3>
+    <ul class="content-text">
+      <li>The referrer that let a user to this website</li>
+      <li>The duration of the visit</li>
+      <li>Information about the client used to access the website</li>
+      <li>other information</li>
+    </ul>
+    <h3 class="pre-heading__text text-align">How we use that data</h3>
+    <p class="content-text text-align">
+      The information recorded by Google Analytics allows us to better understand the audience of this website, what
+      content they’re accessing and how they get here. This allows us to make better decisions about design, writing
+                        and marketing.</p>
+    <p class="content-text text-align">No personally identifying data is ever included in the reports that we run.</p>
+    <p class="content-text text-align">For further information please refer to the
+      <a href="http://www.google.com/analytics/tos.html">Google
+        Analytics Terms of Service</a>.</p>
+    <p class="content-text text-align">Google offers a
+      <a href="http://tools.google.com/dlpage/gaoptout?hl=en">browser plugin</a>
+      to opt out of the
+      Google Analytics tracking service.</p>
+  </div>
+</div>

--- a/2020/index.html
+++ b/2020/index.html
@@ -39,85 +39,85 @@ title: EmberFest
   <div class="sponsors__heading paragraphLarge">Past Sponsors </div>
   <div class="row">
     <a href="https://simplabs.com/" title="simplabs">
-      <img src="/images/sponsors/simplabs.png" alt="simplabs logo" title="simplabs">
+      <img src="/2020/images/sponsors/simplabs.png" alt="simplabs logo" title="simplabs">
     </a>
     <a href="https://getharvest.com/" title="Harvest">
-      <img src="/images/sponsors/harvest.png" alt="Harvest logo" title="Harvest">
+      <img src="/2020/images/sponsors/harvest.png" alt="Harvest logo" title="Harvest">
     </a>
     <a href="https://honeypot.io/" title="honeypot">
-      <img src="/images/sponsors/honeypot.png" alt="honeypot logo" title="honeypot">
+      <img src="/2020/images/sponsors/honeypot.png" alt="honeypot logo" title="honeypot">
     </a>
   </div>
 
   <div class="row">
     <a href="https://www.clark.de/" title="Clark">
-      <img src="/images/sponsors/clark.png" alt="Clark logo" title="Clark">
+      <img src="/2020/images/sponsors/clark.png" alt="Clark logo" title="Clark">
     </a>
     <a href="http://www.triptyk.eu" title="TRIPTYK">
-      <img src="/images/sponsors/TRIPTYK.png" alt="Tryptik logo" title="Tryptik">
+      <img src="/2020/images/sponsors/TRIPTYK.png" alt="Tryptik logo" title="Tryptik">
     </a>
     <a href="https://www.crowdstrike.com" title="CrowdStrike">
-      <img src="/images/sponsors/crowdstrike.png" alt="CrowdStrike logo" alt="CrowdStrike">
+      <img src="/2020/images/sponsors/crowdstrike.png" alt="CrowdStrike logo" alt="CrowdStrike">
     </a>
     <a href="https://www.kloeckner-i.com/" title="kloeckner.i">
-      <img src="/images/sponsors/kloeckner-i.png" alt="Kloeckner logo" title="Kloeckner">
+      <img src="/2020/images/sponsors/kloeckner-i.png" alt="Kloeckner logo" title="Kloeckner">
     </a>
   </div>
 
   <div class="row">
     <a href="https://redpencil.io" title="redpencil.io">
-      <img src="/images/sponsors/redpencil.png" title="RedPencil" alt="RedPencil logo">
+      <img src="/2020/images/sponsors/redpencil.png" title="RedPencil" alt="RedPencil logo">
     </a>
     <a href="https://www.people-doc.com/" title="PeopleDoc">
-      <img src="/images/sponsors/peopledoc.png" alt="PeopleDoc logo" title="PeopleDoc">
+      <img src="/2020/images/sponsors/peopledoc.png" alt="PeopleDoc logo" title="PeopleDoc">
     </a>
     <a href="https://www.addepar.com/" title="Addepar">
-      <img src="/images/sponsors/addepar.png" alt="Addepar logo" title="Addepar">
+      <img src="/2020/images/sponsors/addepar.png" alt="Addepar logo" title="Addepar">
     </a>
   </div>
 
   <div class="row">
     <a href="https://www.precisionnutrition.com/" title="PrecisionNutrition">
-      <img src="/images/sponsors/precnut.png" alt="PrecisionNutrition logo" title="PrecisionNutrition">
+      <img src="/2020/images/sponsors/precnut.png" alt="PrecisionNutrition logo" title="PrecisionNutrition">
     </a>
     <a href="https://cardstack.com/" title="cardstack">
-      <img src="/images/sponsors/cardstack.png" class="img-responsive">
+      <img src="/2020/images/sponsors/cardstack.png" class="img-responsive">
     </a>
     <a href="https://prototypal.io/" title="prototypal">
-      <img src="/images/sponsors/prototypal.png" class="img-responsive">
+      <img src="/2020/images/sponsors/prototypal.png" class="img-responsive">
     </a>
     <a href="http://tilde.io/" title="tilde">
-      <img src="/images/sponsors/tilde.png" class="img-responsive">
+      <img src="/2020/images/sponsors/tilde.png" class="img-responsive">
     </a>
   </div>
 
   <div class="row">
     <a href="http://selleo.com" title="Selleo">
-      <img src="/images/sponsors/selleo.png" class="img-responsive">
+      <img src="/2020/images/sponsors/selleo.png" class="img-responsive">
     </a>
     <a href="http://wyeworks.com" title="Wyeworks">
-      <img src="/images/sponsors/wyeworks.png" class="img-responsive">
+      <img src="/2020/images/sponsors/wyeworks.png" class="img-responsive">
     </a>
     <a href="https://linkfire.com/" title="linkfire">
-      <img src="/images/sponsors/linkfire.png" class="img-responsive">
+      <img src="/2020/images/sponsors/linkfire.png" class="img-responsive">
     </a>
   </div>
 
   <div class="row">
     <a href="https://linkedin.com/" title="linkedin">
-      <img src="/images/sponsors/linkedin.png" class="img-responsive">
+      <img src="/2020/images/sponsors/linkedin.png" class="img-responsive">
     </a>
     <a href="https://www.phorest.com" title="Phorest">
-      <img src="/images/sponsors/phorest.png" title="Phorest" alt="Phorest logo">
+      <img src="/2020/images/sponsors/phorest.png" title="Phorest" alt="Phorest logo">
     </a>
     <a href="https://embermap.com" title="EmberMap">
-      <img src="/images/sponsors/ember-map.png" title="EmberMap" alt="EmberMap logo">
+      <img src="/2020/images/sponsors/ember-map.png" title="EmberMap" alt="EmberMap logo">
     </a>
     <a href="http://stickermule.com/supports/emberfest19-sponsorship" title="Stickermule">
-      <img src="/images/sponsors/sticker-mule.png" title="Stickermule" alt="Stickermule logo">
+      <img src="/2020/images/sponsors/sticker-mule.png" title="Stickermule" alt="Stickermule logo">
     </a>
     <a href="https://emberjs-code-review.com" title="Ember Checkup">
-      <img src="/images/sponsors/ember-checkup.png" title="Ember Checkup" alt="Ember Checkup logo">
+      <img src="/2020/images/sponsors/ember-checkup.png" title="Ember Checkup" alt="Ember Checkup logo">
     </a>
   </div>
 </div>

--- a/2020/privacy/index.html
+++ b/2020/privacy/index.html
@@ -1,0 +1,33 @@
+---
+layout: 2020/default
+title: Privacy
+---
+{% include 2020/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Privacy</h2>
+    <p class="content-text text-align">Emberfest uses Google Analytics to collect user statistics.</p>
+    <p class="content-text text-align">Google Analytics is a service that collects data about website visitors.</p>
+    <h3 class="pre-heading__text text-align">What Google Analytics records</h3>
+    <ul class="content-text">
+      <li>The referrer that let a user to this website</li>
+      <li>The duration of the visit</li>
+      <li>Information about the client used to access the website</li>
+      <li>other information</li>
+    </ul>
+    <h3 class="pre-heading__text text-align">How we use that data</h3>
+    <p class="content-text text-align">
+      The information recorded by Google Analytics allows us to better understand the audience of this website, what
+      content they’re accessing and how they get here. This allows us to make better decisions about design, writing
+                  and marketing.</p>
+    <p class="content-text text-align">No personally identifying data is ever included in the reports that we run.</p>
+    <p class="content-text text-align">For further information please refer to the
+      <a href="http://www.google.com/analytics/tos.html">Google
+        Analytics Terms of Service</a>.</p>
+    <p class="content-text text-align">Google offers a
+      <a href="http://tools.google.com/dlpage/gaoptout?hl=en">browser plugin</a>
+      to opt out of the
+      Google Analytics tracking service.</p>
+  </div>
+</div>

--- a/_includes/2017/cookie_banner.html
+++ b/_includes/2017/cookie_banner.html
@@ -2,7 +2,9 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-1 col-sm-8 col-sm-offset-1 col-xs-12">
-        <p>This website uses cookies. <a href="/privacy/">Learn more</a></p>
+        <p>This website uses cookies.
+          <a href="/2017/privacy/">Learn more</a>
+        </p>
       </div>
       <div class="col-md-4 col-sm-2 col-xs-12">
         <a class="custom-button cookie-button pull-right" id="cookie-button">Ok</a>

--- a/_includes/2018/cookie_banner.html
+++ b/_includes/2018/cookie_banner.html
@@ -2,7 +2,9 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-1 col-sm-8 col-sm-offset-1 col-xs-12">
-        <p>This website uses cookies. <a href="/privacy/">Learn more</a></p>
+        <p>This website uses cookies.
+          <a href="/2018/privacy/">Learn more</a>
+        </p>
       </div>
       <div class="col-md-4 col-sm-2 col-xs-12">
         <a class="custom-button cookie-button pull-right" id="cookie-button">Ok</a>

--- a/_includes/2019/cookie_banner.html
+++ b/_includes/2019/cookie_banner.html
@@ -2,7 +2,9 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-1 col-sm-8 col-sm-offset-1 col-xs-12">
-        <p>This website uses cookies. <a href="/privacy/">Learn more</a></p>
+        <p>This website uses cookies.
+          <a href="/2019/privacy/">Learn more</a>
+        </p>
       </div>
       <div class="col-md-4 col-sm-2 col-xs-12">
         <a class="custom-button cookie-button pull-right" id="cookie-button">Ok</a>

--- a/_includes/2020/cookie_banner.html
+++ b/_includes/2020/cookie_banner.html
@@ -1,5 +1,7 @@
 <div class="cookie-banner" id="cookie-banner">
-  <p>This website uses cookies. <a href="/privacy/">Learn more</a></p>
+  <p>This website uses cookies.
+    <a href="/2020/privacy/">Learn more</a>
+  </p>
   <a class="button cookie-button pull-right" id="cookie-button">Ok</a>
   <script>
     Zepto(function($) {

--- a/_includes/2020/footer.html
+++ b/_includes/2020/footer.html
@@ -1,6 +1,6 @@
 <div class=" footer">
   <div class="footer__wrapper--top">
-    <img class="icon" src="/images/glasses.svg" alt="icon">
+    <img class="icon" src="/2020/images/glasses.svg" alt="icon">
     <div class="footer__copyright paragraphBase">&copy; 2017 - 2020 EmberFest</div>
   </div>
   <hr>

--- a/_includes/2020/footer.html
+++ b/_includes/2020/footer.html
@@ -13,7 +13,7 @@
       Thanks to <a class="footer__links" href='https://ti.to'>Tito</a> for supporting EmberFest <br>Icons from the Noun Project and Freepik
     </div>
     <div class="footer__bottomNav paragraphBase">
-      <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
+      <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/2020/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
     </div>
   </div>
   <hr>


### PR DESCRIPTION
# Description

- fix(2018): privacy link broken
- fix(2017): privacy link restored
- fix(2019): restore privacy link
- fix(2020): restore links to broken images
- fix(2020): restore privacy link

# Context
I run a script to check which are the broken links of past editions and this is the output. There are more links broken that will be addressed in this PR:
- https://github.com/emberfest/emberfest.github.io/pull/385
