### PR TITLE
fix broken links past editions pointing to current edition

### DIFF
--- a/2017/cancellation/index.html
+++ b/2017/cancellation/index.html
@@ -1,0 +1,21 @@
+---
+layout: 2017/default
+title: EmberFest
+---
+{% include 2017/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Cancellation Policy</h2>
+    <h3 class="pre-heading__text text-align">Up to 30 days before the start of the conference</h3>
+    <p class="content-text text-align">
+      Up to 30 days before the start of the conference, you can get a full refund for your ticket. Send an email to mail@emberfest.eu and we will process your refund.
+    </p>
+    <h3 class="pre-heading__text text-align">Within 30 days of the start of the conference</h3>
+    <p class="content-text text-align">
+      We are unable to offer refunds within 30 days of the conference, however your ticket can be reassigned at any time to a different attendee. To reassign your ticket, please follow the link on your original confirmation email.
+    </p>
+    <h3 class="pre-heading__text text-align">“Force majeure” events</h3>
+    <p class="content-text text-align">Should the conference be cancelled for any reason (including due to restrictions because of the Coronavirus pandemic), purchased tickets will be valid for the next year.</p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2017/code-of-conduct/index.html
+++ b/2017/code-of-conduct/index.html
@@ -1,0 +1,44 @@
+---
+layout: 2017/default
+title: EmberFest
+---
+{% include 2017/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Conference Code of Conduct</h2>
+    <p class="content-text text-align">
+      All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody.
+    </p>
+    <h3 class="pre-heading__text text-align">Need Help?</h3>
+    <p class="content-text text-align">
+      You have our contact details in the emails we've sent.
+    </p>
+    <h3 class="pre-heading__text text-align">The Quick Version </h3>
+    <p class="content-text text-align">
+      Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organisers.
+    </p>
+    <h3 class="pre-heading__text text-align">The Less Quick Version</h3>
+    <p class="content-text text-align">
+      Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+    </p>
+    <p class="content-text text-align">
+      Participants asked to stop any harassing behavior are expected to comply immediately.
+    </p>
+    <p class="content-text text-align">
+      Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+    </p>
+    <p class="content-text text-align">
+      If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+    </p>
+    <p class="content-text text-align">
+      If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges.
+    </p>
+    <p class="content-text text-align">
+      Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+    </p>
+    <p class="content-text text-align">
+      We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2017/imprint/index.html
+++ b/2017/imprint/index.html
@@ -1,0 +1,27 @@
+---
+layout: 2017/default
+title: EmberFest
+---
+{% include 2017/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Imprint</h2>
+    <p class="content-text text-align">
+      Publisher information according to §6 Teledienstgesetz (TDG)<br>
+      Responsible according to §6 MDStV:
+    </p>
+    <p class="content-text text-align">
+      EmberFest UG <br>
+      +49 89 452 139 03‬ <br>
+      Marco Otte-Witte <br>
+      Hans-Sachs-Str. 12 <br>
+      80469 München <br>
+      Germany <br>
+    </p>
+    <h3 class="pre-heading__text text-align">Exclusion of Liability </h3>
+    <p class="content-text text-align">
+    We check and update the information on this website regularly. Despite our best efforts, information on the site may not always be correct. Liability concerning timeliness, correctness and completeness of the available information can not be assumed. This applies also for all other websites which are referred via hyperlink. EmberFest UG is not responsible for the content of these third party websites.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2018/cancellation/index.html
+++ b/2018/cancellation/index.html
@@ -1,0 +1,21 @@
+---
+layout: 2018/default
+title: EmberFest
+---
+{% include 2018/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Cancellation Policy</h2>
+    <h3 class="pre-heading__text text-align">Up to 30 days before the start of the conference</h3>
+    <p class="content-text text-align">
+      Up to 30 days before the start of the conference, you can get a full refund for your ticket. Send an email to mail@emberfest.eu and we will process your refund.
+    </p>
+    <h3 class="pre-heading__text text-align">Within 30 days of the start of the conference</h3>
+    <p class="content-text text-align">
+      We are unable to offer refunds within 30 days of the conference, however your ticket can be reassigned at any time to a different attendee. To reassign your ticket, please follow the link on your original confirmation email.
+    </p>
+    <h3 class="pre-heading__text text-align">“Force majeure” events</h3>
+    <p class="content-text text-align">Should the conference be cancelled for any reason (including due to restrictions because of the Coronavirus pandemic), purchased tickets will be valid for the next year.</p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2018/code-of-conduct/index.html
+++ b/2018/code-of-conduct/index.html
@@ -1,0 +1,44 @@
+---
+layout: 2018/default
+title: EmberFest
+---
+{% include 2018/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Conference Code of Conduct</h2>
+    <p class="content-text text-align">
+      All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody.
+    </p>
+    <h3 class="pre-heading__text text-align">Need Help?</h3>
+    <p class="content-text text-align">
+      You have our contact details in the emails we've sent.
+    </p>
+    <h3 class="pre-heading__text text-align">The Quick Version </h3>
+    <p class="content-text text-align">
+      Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organisers.
+    </p>
+    <h3 class="pre-heading__text text-align">The Less Quick Version</h3>
+    <p class="content-text text-align">
+      Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+    </p>
+    <p class="content-text text-align">
+      Participants asked to stop any harassing behavior are expected to comply immediately.
+    </p>
+    <p class="content-text text-align">
+      Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+    </p>
+    <p class="content-text text-align">
+      If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+    </p>
+    <p class="content-text text-align">
+      If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges.
+    </p>
+    <p class="content-text text-align">
+      Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+    </p>
+    <p class="content-text text-align">
+      We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2018/imprint/index.html
+++ b/2018/imprint/index.html
@@ -1,0 +1,27 @@
+---
+layout: 2018/default
+title: EmberFest
+---
+{% include 2018/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Imprint</h2>
+    <p class="content-text text-align">
+      Publisher information according to §6 Teledienstgesetz (TDG)<br>
+      Responsible according to §6 MDStV:
+    </p>
+    <p class="content-text text-align">
+      EmberFest UG <br>
+      +49 89 452 139 03‬ <br>
+      Marco Otte-Witte <br>
+      Hans-Sachs-Str. 12 <br>
+      80469 München <br>
+      Germany <br>
+    </p>
+    <h3 class="pre-heading__text text-align">Exclusion of Liability </h3>
+    <p class="content-text text-align">
+    We check and update the information on this website regularly. Despite our best efforts, information on the site may not always be correct. Liability concerning timeliness, correctness and completeness of the available information can not be assumed. This applies also for all other websites which are referred via hyperlink. EmberFest UG is not responsible for the content of these third party websites.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2018/index.html
+++ b/2018/index.html
@@ -28,7 +28,7 @@ title: EmberFest
     <div class="col-md-6 col-md-offset-3 col-xs-10 col-xs-offset-1 col-sm-8 col-sm-offset-2">
       <h4>Speakers</h4>
       <p>We have a great lineup, including core team members <strong>Melanie Sumner</strong>, <strong>Chad Hietala</strong>
-        and <strong>Tom Dale</strong>! Check the full speakers list <a href="/schedule">here</a>.</p>
+        and <strong>Tom Dale</strong>! Check the full speakers list <a href="/2018/schedule">here</a>.</p>
 
       <div class="row speaker-list">
         <div class="speaker col-md-4 col-md-offset-0 col-xs-4 col-xs-offset-0">

--- a/2019/cancellation/index.html
+++ b/2019/cancellation/index.html
@@ -1,0 +1,21 @@
+---
+layout: 2019/default
+title: EmberFest
+---
+{% include 2019/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Cancellation Policy</h2>
+    <h3 class="pre-heading__text text-align">Up to 30 days before the start of the conference</h3>
+    <p class="content-text text-align">
+      Up to 30 days before the start of the conference, you can get a full refund for your ticket. Send an email to mail@emberfest.eu and we will process your refund.
+    </p>
+    <h3 class="pre-heading__text text-align">Within 30 days of the start of the conference</h3>
+    <p class="content-text text-align">
+      We are unable to offer refunds within 30 days of the conference, however your ticket can be reassigned at any time to a different attendee. To reassign your ticket, please follow the link on your original confirmation email.
+    </p>
+    <h3 class="pre-heading__text text-align">“Force majeure” events</h3>
+    <p class="content-text text-align">Should the conference be cancelled for any reason (including due to restrictions because of the Coronavirus pandemic), purchased tickets will be valid for the next year.</p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2019/code-of-conduct/index.html
+++ b/2019/code-of-conduct/index.html
@@ -1,0 +1,44 @@
+---
+layout: 2019/default
+title: EmberFest
+---
+{% include 2019/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Conference Code of Conduct</h2>
+    <p class="content-text text-align">
+      All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody.
+    </p>
+    <h3 class="pre-heading__text text-align">Need Help?</h3>
+    <p class="content-text text-align">
+      You have our contact details in the emails we've sent.
+    </p>
+    <h3 class="pre-heading__text text-align">The Quick Version </h3>
+    <p class="content-text text-align">
+      Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organisers.
+    </p>
+    <h3 class="pre-heading__text text-align">The Less Quick Version</h3>
+    <p class="content-text text-align">
+      Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+    </p>
+    <p class="content-text text-align">
+      Participants asked to stop any harassing behavior are expected to comply immediately.
+    </p>
+    <p class="content-text text-align">
+      Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+    </p>
+    <p class="content-text text-align">
+      If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+    </p>
+    <p class="content-text text-align">
+      If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges.
+    </p>
+    <p class="content-text text-align">
+      Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+    </p>
+    <p class="content-text text-align">
+      We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2019/imprint/index.html
+++ b/2019/imprint/index.html
@@ -1,0 +1,27 @@
+---
+layout: 2019/default
+title: EmberFest
+---
+{% include 2019/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Imprint</h2>
+    <p class="content-text text-align">
+      Publisher information according to §6 Teledienstgesetz (TDG)<br>
+      Responsible according to §6 MDStV:
+    </p>
+    <p class="content-text text-align">
+      EmberFest UG <br>
+      +49 89 452 139 03‬ <br>
+      Marco Otte-Witte <br>
+      Hans-Sachs-Str. 12 <br>
+      80469 München <br>
+      Germany <br>
+    </p>
+    <h3 class="pre-heading__text text-align">Exclusion of Liability </h3>
+    <p class="content-text text-align">
+    We check and update the information on this website regularly. Despite our best efforts, information on the site may not always be correct. Liability concerning timeliness, correctness and completeness of the available information can not be assumed. This applies also for all other websites which are referred via hyperlink. EmberFest UG is not responsible for the content of these third party websites.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2020/cancellation/index.html
+++ b/2020/cancellation/index.html
@@ -1,0 +1,21 @@
+---
+layout: 2020/default
+title: EmberFest
+---
+{% include 2020/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Cancellation Policy</h2>
+    <h3 class="pre-heading__text text-align">Up to 30 days before the start of the conference</h3>
+    <p class="content-text text-align">
+      Up to 30 days before the start of the conference, you can get a full refund for your ticket. Send an email to mail@emberfest.eu and we will process your refund.
+    </p>
+    <h3 class="pre-heading__text text-align">Within 30 days of the start of the conference</h3>
+    <p class="content-text text-align">
+      We are unable to offer refunds within 30 days of the conference, however your ticket can be reassigned at any time to a different attendee. To reassign your ticket, please follow the link on your original confirmation email.
+    </p>
+    <h3 class="pre-heading__text text-align">“Force majeure” events</h3>
+    <p class="content-text text-align">Should the conference be cancelled for any reason (including due to restrictions because of the Coronavirus pandemic), purchased tickets will be valid for the next year.</p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2020/code-of-conduct/index.html
+++ b/2020/code-of-conduct/index.html
@@ -1,0 +1,44 @@
+---
+layout: 2020/default
+title: EmberFest
+---
+{% include 2020/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Conference Code of Conduct</h2>
+    <p class="content-text text-align">
+      All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organisers will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everybody.
+    </p>
+    <h3 class="pre-heading__text text-align">Need Help?</h3>
+    <p class="content-text text-align">
+      You have our contact details in the emails we've sent.
+    </p>
+    <h3 class="pre-heading__text text-align">The Quick Version </h3>
+    <p class="content-text text-align">
+      Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organisers.
+    </p>
+    <h3 class="pre-heading__text text-align">The Less Quick Version</h3>
+    <p class="content-text text-align">
+      Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+    </p>
+    <p class="content-text text-align">
+      Participants asked to stop any harassing behavior are expected to comply immediately.
+    </p>
+    <p class="content-text text-align">
+      Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+    </p>
+    <p class="content-text text-align">
+      If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+    </p>
+    <p class="content-text text-align">
+      If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges.
+    </p>
+    <p class="content-text text-align">
+      Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+    </p>
+    <p class="content-text text-align">
+      We expect participants to follow these rules at conference and workshop venues and conference-related social events.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/2020/imprint/index.html
+++ b/2020/imprint/index.html
@@ -1,0 +1,27 @@
+---
+layout: 2020/default
+title: EmberFest
+---
+{% include 2020/main_header.html %}
+
+<div class="coc-wrapper">
+  <div class="container tb_padding">
+    <h2 class="pre-heading__text text-align">Imprint</h2>
+    <p class="content-text text-align">
+      Publisher information according to §6 Teledienstgesetz (TDG)<br>
+      Responsible according to §6 MDStV:
+    </p>
+    <p class="content-text text-align">
+      EmberFest UG <br>
+      +49 89 452 139 03‬ <br>
+      Marco Otte-Witte <br>
+      Hans-Sachs-Str. 12 <br>
+      80469 München <br>
+      Germany <br>
+    </p>
+    <h3 class="pre-heading__text text-align">Exclusion of Liability </h3>
+    <p class="content-text text-align">
+    We check and update the information on this website regularly. Despite our best efforts, information on the site may not always be correct. Liability concerning timeliness, correctness and completeness of the available information can not be assumed. This applies also for all other websites which are referred via hyperlink. EmberFest UG is not responsible for the content of these third party websites.
+    </p>
+  </div> <!-- paragraphLarge -->
+</div> <!-- wrapper -->

--- a/_includes/2017/footer.html
+++ b/_includes/2017/footer.html
@@ -13,8 +13,8 @@
     <a href="/2019">2019</a>
     <a href="/2018">2018</a>
     <a href="/2017">2017</a>
-    <a href="/code-of-conduct">Code of Conduct</a>
-    <a href="/cancellation">Cancellation</a>
-    <a href="/imprint">Imprint</a>
+    <a href="/2017/code-of-conduct">Code of Conduct</a>
+    <a href="/2017/cancellation">Cancellation</a>
+    <a href="/2017/imprint">Imprint</a>
   </div>
 </div>

--- a/_includes/2018/footer.html
+++ b/_includes/2018/footer.html
@@ -13,8 +13,8 @@
     <a href="/2019">2019</a>
     <a href="/2018">2018</a>
     <a href="/2017">2017</a>
-    <a href="/code-of-conduct">Code of Conduct</a>
-    <a href="/cancellation">Cancellation</a>
-    <a href="/imprint">Imprint</a>
+    <a href="/2018/code-of-conduct">Code of Conduct</a>
+    <a href="/2018/cancellation">Cancellation</a>
+    <a href="/2018/imprint">Imprint</a>
   </div>
 </div>

--- a/_includes/2019/footer.html
+++ b/_includes/2019/footer.html
@@ -13,8 +13,8 @@
     <a href="/2019">2019</a>
     <a href="/2018">2018</a>
     <a href="/2017">2017</a>
-    <a href="/code-of-conduct">Code of Conduct</a>
-    <a href="/cancellation">Cancellation</a>
-    <a href="/imprint">Imprint</a>
+    <a href="/2019/code-of-conduct">Code of Conduct</a>
+    <a href="/2019/cancellation">Cancellation</a>
+    <a href="/2019/imprint">Imprint</a>
   </div>
 </div>

--- a/_includes/2020/footer.html
+++ b/_includes/2020/footer.html
@@ -13,7 +13,7 @@
       Thanks to <a class="footer__links" href='https://ti.to'>Tito</a> for supporting EmberFest <br>Icons from the Noun Project and Freepik
     </div>
     <div class="footer__bottomNav paragraphBase">
-      <a class="footer__links" href="/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/cancellation">Cancellation</a> • <a class="footer__links" href="/2020/privacy">Privacy</a> • <a class="footer__links" href="/imprint">Imprint</a>
+      <a class="footer__links" href="/2020/code-of-conduct">Code of Conduct</a> • <a class="footer__links" href="/2020/cancellation">Cancellation</a> • <a class="footer__links" href="/2020/privacy">Privacy</a> • <a class="footer__links" href="/2020/imprint">Imprint</a>
     </div>
   </div>
   <hr>


### PR DESCRIPTION
- fix(2017): restore footer links
- fix(2018): footer links and /schedule restored
- fix(2019): restore footer links
- fix(2020): restore footer links
