### PR TITLE
Make sidepages titles smaller

### DIFF
--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -8,7 +8,7 @@ title: EmberFest
 
 <main>
   <section>
-    <h3>Conference Code of Conduct</h3>
+    <h3 class="conduct__title">Conference Code of Conduct</h3>
     <div class="content">
       <p>
         All attendees, speakers, sponsors and volunteers at our conference are

--- a/css/sidepages.scss
+++ b/css/sidepages.scss
@@ -109,8 +109,8 @@ h3 {
     margin-bottom: 40px;
     max-width: initial;
     @include responsiveTitle(80%, 2.875rem);
-    &.cancellation__title {
-      @include responsiveTitle(80%, 2.875rem, 11vw);
+    &.cancellation__title, &.conduct__title, &.imprint__title  {
+      @include responsiveTitle(80%, 2.875rem, 10.5vw);
     }
   }
 

--- a/imprint/index.html
+++ b/imprint/index.html
@@ -8,7 +8,7 @@ title: EmberFest
 
 <main>
   <section>
-    <h3 >Imprint</h3>
+    <h3 class="imprint__title" >Imprint</h3>
     <div class="content">
       <div class="imprint__responsible_info">
         <p>


### PR DESCRIPTION
I noticed that on mobile, the titles of the cancellation and code of conduct pages couldn't be shown fully, so I'm reducing a bit their max font-size.