### PR TITLE
Reduce side pages titles

### DIFF
--- a/css/sidepages.scss
+++ b/css/sidepages.scss
@@ -110,7 +110,7 @@ h3 {
     max-width: initial;
     @include responsiveTitle(80%, 2.875rem);
     &.cancellation__title, &.conduct__title, &.imprint__title  {
-      @include responsiveTitle(80%, 2.875rem, 10.5vw);
+      @include responsiveTitle(80%, 2.875rem, 10vw);
     }
   }
 


### PR DESCRIPTION
I'm reducing a bit more because the Cancellation Policy title still looks very close to the edges of the screen.