### PR TITLE
fix(past-sponsors): adjust spacing between logos in small mobiles and tablet

### DIFF
--- a/css/_past-sponsors.scss
+++ b/css/_past-sponsors.scss
@@ -44,7 +44,13 @@
     margin: 0 18px;
     justify-content: space-evenly;
     padding: 25px;
-    gap: 25px;
+    column-gap: 25px;
+    row-gap: 40px;
+
+    @include sm {
+      gap: 40px;
+    }
+    
     @include lg {
       padding: 65px;
       gap: 80px;


### PR DESCRIPTION
# Description
- **mobile**: use a `row-gap: 40px` for mobile (screens below `640px width`)
- **tablet**: use a `column` and `row` `gap` of `40px` (screens between `640px` and `1024px` `width`)
