### PR TITLE
fix(venue): adjust image size in small mobile screen

### DIFF
--- a/css/_venue.scss
+++ b/css/_venue.scss
@@ -40,7 +40,7 @@
 
     img {
       margin-bottom: 40px;
-      max-width: 360px;
+      max-width: min(90vw, 360px);
     }
 
     @include lg {


### PR DESCRIPTION
# Description
- Venue image breaks on small mobile (iPhone SE) before this changes

| before | after |
|--------|--------|
| ![image](https://github.com/emberfest/emberfest.github.io/assets/2574275/119d6cbd-f4be-48da-b93e-43569524ce43) | ![image](https://github.com/emberfest/emberfest.github.io/assets/2574275/08e57e2c-ab9c-4049-be03-ba6904c71767) | 