### PR TITLE
Fix 2023 schedule, speakers and sponsors

### DIFF
--- a/2023/schedule/day/1/index.html
+++ b/2023/schedule/day/1/index.html
@@ -5,7 +5,7 @@ title: EmberFest – Schedule day 1
 
 {% include 2023/sidepages_header.html %}
 
-{% assign day = site.data.schedule[0] %}
+{% assign day = site.data.2023.schedule[0] %}
 
 <main>
   <section class="full-schedule-day">

--- a/2023/schedule/day/2/index.html
+++ b/2023/schedule/day/2/index.html
@@ -6,7 +6,7 @@ title: EmberFest – Schedule day 2
 
 {% include 2023/sidepages_header.html %}
 
-{% assign day = site.data.schedule[1] %}
+{% assign day = site.data.2023.schedule[1] %}
 
 <main>
   <section class="full-schedule-day">

--- a/_includes/2023/schedule.html
+++ b/_includes/2023/schedule.html
@@ -1,7 +1,7 @@
 <section class="schedule" id="schedule">
   <h3>Schedule</h3>
   <div class="data">
-    {% for day in site.data.schedule %}
+    {% for day in site.data.2023.schedule %}
       <div class="day">
         <div class="content">
           <h4>{{day.label}}</h4>

--- a/_includes/2023/sponsors.html
+++ b/_includes/2023/sponsors.html
@@ -1,10 +1,10 @@
 <section class="sponsors">
 	<h3>Sponsors</h3>
-  {% if site.data.sponsors.premier_partners %}
+  {% if site.data.2023.sponsors.premier_partners %}
   <div class="sponsor-section-wrapper">
     <h4>Premier Partners</h4>
     <ul class="sponsors-list premier-partner">
-      {% for sponsor in site.data.sponsors.premier_partners %}
+      {% for sponsor in site.data.2023.sponsors.premier_partners %}
       <li>
         <a href="{{ sponsor.link }}">
           <img src="/2023/images/sponsors/{{sponsor.logo}}.svg" />
@@ -14,11 +14,11 @@
     </ul>
   </div>
   {% endif %}
-  {% if site.data.sponsors.dinner %}
+  {% if site.data.2023.sponsors.dinner %}
   <div class="sponsor-section-wrapper">
     <h4>Dinner Sponsor</h4>
     <ul class="sponsors-list dinner-sponsors">
-      {% for sponsor in site.data.sponsors.dinner %}
+      {% for sponsor in site.data.2023.sponsors.dinner %}
       <li>
         <a href="{{ sponsor.link }}">
           <img src="/2023/images/sponsors/{{sponsor.logo}}.svg" />
@@ -28,11 +28,11 @@
     </ul>
   </div>
   {% endif %}
-  {% if site.data.sponsors.partners %}
+  {% if site.data.2023.sponsors.partners %}
   <div class="sponsor-section-wrapper">
     <h4>Partners</h4>
     <ul class="sponsors-list partners">
-      {% for sponsor in site.data.sponsors.partners %}
+      {% for sponsor in site.data.2023.sponsors.partners %}
       <li>
         <a href="{{ sponsor.link }}">
           <img src="/2023/images/sponsors/{{sponsor.logo}}.svg" />
@@ -42,11 +42,11 @@
     </ul>
   </div>
   {% endif %}
-  {% if site.data.sponsors.supporters %}
+  {% if site.data.2023.sponsors.supporters %}
   <div class="sponsor-section-wrapper">
     <h4>Supporters</h4>
     <ul class="sponsors-list supporters">
-      {% for sponsor in site.data.sponsors.supporters %}
+      {% for sponsor in site.data.2023.sponsors.supporters %}
       <li>
         <a href="{{ sponsor.link }}">
           <img src="/2023/images/sponsors/{{sponsor.logo}}.svg" />


### PR DESCRIPTION
tl;dr: The content on https://emberfest.eu/2023 is a copy of this year's and this PR fixes that.

Here is the longer story (kinda important so that we don't make the same mistake next year):

Tomek pointed to me that the 2023 schedule is a copy of this year's schedule.

I remember checking the 2023 schedule myself *before* posting this year's one and I remember it was correct back then. To my surprise, Tomek was right: the 2023 schedule is now the same as this year's which this PR fixes.

I'm fairly certain what happened is that when we archived last year's content, we didn't make a full copy of the content (stored in `.yml` files), so the 2023 pages just kept referring to `data.site.schedule`. Which was fine until the schedule wasn't update for this year 😅 