### PR TITLE
fix(button): apply padding for >=1024px viewport width

### DIFF
--- a/css/_buttons.scss
+++ b/css/_buttons.scss
@@ -1,6 +1,8 @@
 .btn-shadow {
   filter: $shadow;
-  padding:2rem;
+  @include lg {
+    padding:2rem;
+  }
 }
 
 .btn-primary {


### PR DESCRIPTION
This prevents adding an unnecessary extra padding on small screen causing the undesired horizontal scroll

Fixes #471 