### PR TITLE
Add Yehuda to the main page as a speaker

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -2,6 +2,11 @@
   avatar: "edward-faulkner.jpeg"
   twitter: "https://twitter.com/eaf4"
   web: "https://www.linkedin.com/in/edwardfaulkner/"
+- name: "Yehuda Katz"
+  avatar: "yehuda-katz.jpeg"
+  web: "https://www.linkedin.com/in/yehudakatz/"
+  twitter: "https://x.com/wycats"
+  bluesky: https://bsky.app/profile/wycats.bsky.social
 
 - name: "Melanie Sumner"
   avatar: "melanie-sumner.jpg"


### PR DESCRIPTION
This is unfortunately not easy as that as we don't have a blue or yellow bg image of Yehuda and this looks somewhat odd:

<img width="932" height="933" alt="Screenshot 2025-08-27 at 15 47 21" src="https://github.com/user-attachments/assets/ff96cb1a-e2e6-41ee-ad20-471a4d7f1a85" />
