### PR TITLE
Remove duplicate "Submit a Talk" link below Organizers section

### DIFF
--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -48,7 +48,4 @@
   </div>
 
   {% include organizers.html %}
-  <a class="button btn-primary mt-8" href="https://forms.gle/EfCzgXaDdnHFWYRF9" target="_blank" alt="Submit a Talk">
-    Submit a Talk
-  </a>
 </section>


### PR DESCRIPTION
The link at the top of the page (next to "Get your ticket!") remains.